### PR TITLE
Use multistage build for collector

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -1,49 +1,30 @@
-FROM ubuntu:22.04
-ENV DEV_ROOT=/app
-ENV XDG_CACHE_HOME=/app
-ENV DEBIAN_FRONTEND=noninteractive
-WORKDIR ${DEV_ROOT}
+FROM docker.io/library/rust:1.87 AS qmassa
 
-
-# install telegraf & intel-gpu-tools (which includes intel_gpu_top)
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    sudo vim curl unzip git lsof wget \
-    python3 python3-dev python3-pip \
-    gnupg supervisor \
-    linux-tools-common linux-tools-generic linux-cloud-tools-generic \
-    build-essential pkg-config libfontconfig-dev libudev-dev \
-    jq libcap2-bin && \
-    # Add InfluxData GPG key and repo
-    curl -s https://repos.influxdata.com/influxdata-archive.key -o influxdata-archive.key && \
-    echo '943666881a1b8d9b849b74caebf02d3465d6beb716510d86a39f6c8e8dac7515 influxdata-archive.key' | sha256sum -c - && \
-    gpg --dearmor < influxdata-archive.key > /etc/apt/trusted.gpg.d/influxdata-archive.gpg && \
-    echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' > /etc/apt/sources.list.d/influxdata.list && \
-    rm influxdata-archive.key && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends telegraf && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    # Install Python requirements
-    python3 -m pip install --upgrade pip 
+    apt-get install -y --no-install-recommends \
+        libudev-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-
-# Install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y 
-
-# Configure cargo
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install qmassa
 RUN cargo install --locked qmassa
 
+FROM docker.io/library/telegraf:1.32 AS collector
+
+COPY --from=qmassa /usr/local/cargo/bin/qmassa /usr/local/bin/qmassa
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        supervisor && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY qmassa_reader.py qmassa_reader.py
+COPY read_cpu_freq.sh read_cpu_freq.sh
+RUN chmod +x read_cpu_freq.sh
 
 COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-COPY qmassa_reader.py ${DEV_ROOT}/qmassa_reader.py
-COPY read_cpu_freq.sh ${DEV_ROOT}/read_cpu_freq.sh
-RUN chmod +x ${DEV_ROOT}/read_cpu_freq.sh
-EXPOSE 7005
-ENV PORT=7005
-
 
 ENTRYPOINT ["/usr/bin/supervisord"]


### PR DESCRIPTION
### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

This PR reduces the size of the collector image, by using multistage build, removing build deps from final images.
Size of image should be around 529MB now, instead of 2GB

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

No new deps.
We were already using cargo/rust before, now it is coming from dockerhub
We are adding telegraf container image as the base for collector

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Locally, in Intel Core Ultra 7 155H

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

